### PR TITLE
scripts: Add commandline provider (cl).

### DIFF
--- a/scripts/tues-provider-cl
+++ b/scripts/tues-provider-cl
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+# coding: utf-8
+"""Tues provider that provides hosts names as specified on the commandline.
+
+Usage:
+  tues-provider-cl <hosts> ...
+
+Options:
+  <hosts> ...               Host names
+
+Example:
+  tues ls cl host1 host2 host3
+"""
+
+import docopt as _docopt
+
+if __name__ == '__main__':
+    args = _docopt.docopt(__doc__)
+    for host in args["<hosts>"]:
+        print host


### PR DESCRIPTION
Allows specifying hosts on the command line. Especially useful with
shell features like:

  tues <cmd> cl somehost{01..10}
