### PR TITLE
tues: Fix --file option.

### DIFF
--- a/scripts/tues
+++ b/scripts/tues
@@ -81,7 +81,7 @@ if __name__ == '__main__':
                 run_cmd,
                 cmd=args['<command>'],
                 user=args['--user'],
-                put_files=args["--file"],
+                put_files=[args["--file"]],
             ),
             hosts=hosts,
         )


### PR DESCRIPTION
The --file option has a single value, but run_cmd expects a list of
paths. Don't know how this ever worked.

One could also change run_cmd to only expect a single path, but
eventually supporting multiple put-files seems useful.
