### PR TITLE
tues: Fix --file option again

### DIFF
--- a/scripts/tues
+++ b/scripts/tues
@@ -81,7 +81,7 @@ if __name__ == '__main__':
                 run_cmd,
                 cmd=args['<command>'],
                 user=args['--user'],
-                put_files=[args["--file"]],
+                put_files=[args["--file"]] if args["--file"] else None,
             ),
             hosts=hosts,
         )


### PR DESCRIPTION
The previous fix passed `[None]` as the `put_files` argument of
`run_cmd` when the file option was not used. Helpfully, `fabric.put`
interprets `local_path=None` as "recursively upload the current
directory".
