### PR TITLE
scripts/tues: Delete uploaded files after command execution

### DIFF
--- a/scripts/tues
+++ b/scripts/tues
@@ -26,6 +26,7 @@ import functools as _ft
 import subprocess as _sp
 import getpass as _getpass
 import logging as _logging
+import contextlib as _contextlib
 
 import docopt as _docopt
 import fabric.api as _fabric
@@ -47,20 +48,38 @@ if pw:
 
 
 def run_cmd(cmd, user=None, put_files=None):
-    shell_env = {}
-
-    if put_files is not None:
-        for pos, file in enumerate(put_files, start=1):
-            _fabric.put(file)
-            shell_env["TUES_FILE{}".format(pos)] = _os.path.basename(file)
-
-    with _fabric.shell_env(**shell_env): # pylint: disable=not-context-manager
+    with remote_files(put_files) as shell_env, _fabric.shell_env(**shell_env): # pylint: disable=not-context-manager
         if user is None:
             _fabric.run(cmd)
         else:
             _fabric.sudo(cmd, user=user)
 
     _fabric_state.connections[_fabric.env.host_string].get_transport().close()
+
+
+@_contextlib.contextmanager
+def remote_files(paths):
+    """Context manager that provides files specified by `paths` on the remote side
+
+    All files listed in paths are uploaded to the remote host. The resulting absolute paths are
+    provided in a dictionary with keys "TUES_FILE<n>" where <n> starts at one an matches the order
+    in `paths`. When the context is exited, the files are removed from the remote host.
+    """
+    remote_paths = []
+    env = {}
+    for pos, path in enumerate(paths or [], start=1):
+        put_res = _fabric.put(path)
+        if put_res.failed:
+            raise ValueError("Failed to upload file {}".format(path))
+        remote_path = str(put_res[0])
+        remote_paths.append(remote_path)
+        env["TUES_FILE{}".format(pos)] = remote_path
+
+    try:
+        yield env
+    finally:
+        if remote_paths:
+            _fabric.run("rm {}".format(" ".join("'{}'".format(path) for path in remote_paths)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We previously left behind the files provided through the `-f` switch.
To fix this, move the file handling code into a context manager. We
now use the return value of `fabric.api.put` to determine whether the
upload succeeded and to provide the absolute path to the uploaded file
in the environment variable.