### PR TITLE
Handle "no hosts" case in `run`

### DIFF
--- a/src/tues/__init__.py
+++ b/src/tues/__init__.py
@@ -1025,6 +1025,8 @@ def run(
     """
     if isinstance(hosts, (str, tuple)):
         hosts = [hosts]
+    elif not hosts:
+        raise TuesError("No hosts")
 
     hosts = [Host(_) for _ in hosts]
 


### PR DESCRIPTION
I'm undecided whether this is the right thing to do, or whether we should rather return an empty list. The empty list is easy to detect for the caller in case they want to raise an error, but then again, they shouldn't have called `run` with an empty host list in the first place. So maybe raising a generic exception is the right thing to do after all.